### PR TITLE
Fix unit selection crash

### DIFF
--- a/app/src/main/java/com/example/proyecto/fragments/AlmacenFragment.kt
+++ b/app/src/main/java/com/example/proyecto/fragments/AlmacenFragment.kt
@@ -170,7 +170,7 @@ class AlmacenFragment : Fragment(R.layout.fragment_almacen) {
                                 category = "personalizada"
                             }
                             //crear el alimento
-                            val unidadSeleccionada = Unidad.valueOf(spinner.selectedItem.toString().toUpperCase())
+                            val unidadSeleccionada = Unidad.values()[spinner.selectedItemPosition]
                             val alimento: Alimento = Alimento(autoCompleteTextView.text.toString(), category.toString(), cantidadAlimento, unidadSeleccionada)
                             //añadir el alimento a la lista de alimentos del almacen
                             alimentosAlmacenList.add(alimento)


### PR DESCRIPTION
## Summary
- fix unit selection by using spinner index to handle accented unit names

## Testing
- `./gradlew test` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6840812dbb0c832a8cb9b54b1680c03f